### PR TITLE
Fix Arbitray file write on wisper

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "bunyan": "^1.0.1",
     "jasmine-node": "^1.14.5",
     "underscore": "^1.6.0",
+    "unique-filename": "^1.1.1",
     "verror": "^1.6.0",
     "ws": "^0.4.31"
   }

--- a/wisper.js
+++ b/wisper.js
@@ -25,14 +25,25 @@ var VError = require('verror');
 var async = require('async');
 var uniqueFilename = require('unique-filename')
 const os = require('os');
+const fs = require('fs');
 
 
 // [ Logging ]
+var logfile = '/tmp/wisper.log'
+try {
+  var logStat = fs.lstatSync(logfile);
+  if (logStat.isSymbolicLink()){
+    logfile = uniqueFilename(os.tmpdir(),'wisper')+'.log';
+    console.log('Default log file is a symbolik link, a random one will be used instead -> ', logfile)
+  }
+} catch(err) {
+  console.log(err)
+}
 var log = bunyan.createLogger({
     serializers: bunyan.stdSerializers,
     name: 'wisper',
     streams: [{
-        path: uniqueFilename(os.tmpdir(),'wisper')+'.log',
+        path: logfile,
         type: 'rotating-file',
         period: '1d',
         count: 3,

--- a/wisper.js
+++ b/wisper.js
@@ -23,6 +23,8 @@ var ws = require('ws');
 var bunyan = require('bunyan');
 var VError = require('verror');
 var async = require('async');
+var uniqueFilename = require('unique-filename')
+const os = require('os');
 
 
 // [ Logging ]
@@ -30,7 +32,7 @@ var log = bunyan.createLogger({
     serializers: bunyan.stdSerializers,
     name: 'wisper',
     streams: [{
-        path: '/tmp/wisper.log',
+        path: uniqueFilename(os.tmpdir(),'wisper')+'.log',
         type: 'rotating-file',
         period: '1d',
         count: 3,


### PR DESCRIPTION
### 📊 Metadata *

wisper is minimalist websocket pub/sub with regex subscriptions, this package are vulnerable to Arbitrary File Write.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-wisper

### ⚙️ Description *

Since wisper log file is always write to same location, malicious user could create symlink to other place causing lost of data or private data disclosure

### 💻 Technical Description *

log file location is tested to be symlink and in case of possitive a randomly generetaed one will be used insted, using unique-filename.

### 🐛 Proof of Concept (PoC) *

1. Download wisper
2. create symlink from /tmp/wisper.log to new location
`ln -s ~/HACKED /tmp/wisper.log`
3. Start wisper
`node wisper`
4. Content from log is written in arbitrary location defined by attacker
5. See content in new location
`cat ~/HACKED` 

![Captura de pantalla de 2020-09-09 17-24-42](https://user-images.githubusercontent.com/7505980/92611449-785a1180-f2c1-11ea-8485-7ae2a071ddb7.png)

### 🔥 Proof of Fix (PoF) *

After fix synlink can be detected and random file used instead

![Captura de pantalla de 2020-09-12 12-45-10](https://user-images.githubusercontent.com/7505980/92992786-32d25a00-f4f6-11ea-9052-c4a1d43b6bac.png)

### 👍 User Acceptance Testing (UAT)

Functionality unafected

### References
https://github.com/JacksonGL/NPM-Vuln-PoC/tree/master/arbitrary-write
https://blog.daniel-ruf.de/critical-design-flaw-npm-pnpm-yarn/